### PR TITLE
token validation: token validation request contains other cookies

### DIFF
--- a/ngx_http_auth_crowd_module.c
+++ b/ngx_http_auth_crowd_module.c
@@ -343,7 +343,7 @@ create_sso_session(ngx_http_request_t *r, ngx_http_auth_crowd_loc_conf_t *alcf, 
 }
 
 int
-validate_sso_session_token(ngx_http_request_t *r, ngx_http_auth_crowd_loc_conf_t *alcf, const char *token)
+validate_sso_session_token(ngx_http_request_t *r, ngx_http_auth_crowd_loc_conf_t *alcf, ngx_str_t *token)
 {
 	const char *url_template = "%V/rest/usermanagement/latest/session/%s";
 	u_char session_json[256] = { '\0' };
@@ -497,7 +497,7 @@ ngx_http_auth_crowd_handler(ngx_http_request_t *r)
 	name.len = strlen(ctx->name);
 	rc = ngx_http_auth_crowd_get_token(r, &name,  &token);
 	if (rc != NGX_DECLINED) {
-		rc = validate_sso_session_token(r, alcf, (const char *)token.data);
+		rc = validate_sso_session_token(r, alcf, &token);
 		if (rc != NGX_OK)
 			return ngx_http_auth_crowd_set_realm(r, &alcf->realm);
 	}


### PR DESCRIPTION
Thanks for the nginx module :)

My nginx error log showed requests like
> POST /crowd/rest/usermanagement/latest/session/aPwpacdLc5W0lqB90dEMtg00; othercookie="1234567890abcdef HTTP/1.1

After looking around it looked like that the `validate_sso_session_token` `token` argument contains not only our needed crowd session token, but all other cookies in the cookie header too.

I changed it to use `ngx_str_t`, the `ngx_snprintf` for building the crowd request url is fine with that.


