### PR TITLE
Fix outdated code, verbose logging and config

### DIFF
--- a/config
+++ b/config
@@ -3,6 +3,7 @@ ngx_addon_name=ngx_http_auth_crowd_module
 if test -n "$ngx_module_link"; then
     ngx_module_type=HTTP
     ngx_module_name=ngx_http_auth_crowd_module
+    ngx_module_libs="$(${PKG_CONFIG:=pkg-config} --libs curl)"
     ngx_module_srcs="$ngx_addon_dir/ngx_http_auth_crowd_module.c"
     . auto/module
 else


### PR DESCRIPTION
This defines the requirement on curl better, doesn't log all output for each request and uses `ngx_str_set` where it can.